### PR TITLE
[cli] place command after global options

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,7 +450,7 @@
                             <h3>Example Usage</h3>
                             <div class="example-block">
                                 <code># Send an SMS message<br/>
-                                smsgate send -u &lt;username&gt; -p &lt;password&gt; --phone '+19162255887' 'Hello, Dr. Turk!'</code>
+                                smsgate -u &lt;username&gt; -p &lt;password&gt; send --phone '+19162255887' 'Hello, Dr. Turk!'</code>
                                 <button class="copy-button" onclick="copyCode(this)">Copy</button>
                             </div>
                             <div class="example-block">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated CLI examples to show global flags before the subcommand (e.g., smsgate -u <username> -p <password> send --phone ...), improving clarity and aligning guidance with current behavior. No functional changes or API updates; existing commands continue to work as before. This revision aims to reduce confusion and make credential/option usage more discoverable in the CLI section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->