### PR TITLE
[seo] add agent discovery endpoints and headers

### DIFF
--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "smsgate",
+      "type": "skill-md",
+      "description": "Integrating SMSGate with AI agents: sending and receiving SMS, webhooks, and JWT authentication",
+      "url": "https://docs.sms-gate.app/skill.md",
+      "digest": "sha256:fcd485c24333fd387ce0c87030d3ecc706cedeb2741fde95ee44ce2138ffef2a"
+    }
+  ]
+}

--- a/.well-known/api-catalog
+++ b/.well-known/api-catalog
@@ -1,0 +1,25 @@
+{
+    "linkset": [
+        {
+            "anchor": "https://api.sms-gate.app/3rdparty/v1",
+            "service-desc": [
+                {
+                    "href": "https://api.sms-gate.app/docs/doc.json",
+                    "type": "application/json"
+                }
+            ],
+            "service-doc": [
+                {
+                    "href": "https://docs.sms-gate.app/",
+                    "type": "text/html"
+                }
+            ],
+            "status": [
+                {
+                    "href": "https://api.sms-gate.app/3rdparty/v1/health/ready",
+                    "type": "application/json"
+                }
+            ]
+        }
+    ]
+}

--- a/_headers
+++ b/_headers
@@ -3,6 +3,7 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
+  Link: </.well-known/api-catalog>; rel="api-catalog", <https://docs.sms-gate.app/>; rel="service-doc", <https://api.sms-gate.app/docs/doc.json>; rel="describedby"
 
 # Long-lived cache for fingerprinted assets
 /android-chrome-*.png
@@ -15,3 +16,14 @@
   Cache-Control: public, max-age=31536000, immutable
 /site.webmanifest
   Cache-Control: public, max-age=86400
+
+# Agent-readiness discovery endpoints
+/.well-known/api-catalog
+  Content-Type: application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"
+  Cache-Control: public, max-age=3600
+  Link: </.well-known/api-catalog>; rel="api-catalog"
+/.well-known/agent-skills/index.json
+  Content-Type: application/json
+  Cache-Control: public, max-age=3600
+/auth.md
+  Content-Type: text/markdown

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
 Sitemap: https://sms-gate.app/sitemap.xml
+Content-Signal: ai-train=no, search=yes, ai-input=no


### PR DESCRIPTION
Add AI agent discovery support to the landing site:
- Link response headers (RFC 8288) pointing to api-catalog, service-doc, describedby
- Content-Signal directives in robots.txt (ai-train=no, search=yes, ai-input=no)
- RFC 9727 API catalog at /.well-known/api-catalog
- Agent Skills discovery index (v0.2.0) referencing docs skill.md
- MCP server card at /.well-known/mcp/server-card.json
- auth.md documenting Basic and JWT authentication for agents
- WebMCP tools (send_sms, open_docs) via navigator.modelContext.registerTool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized discovery metadata for the SMS Gate API, including service documentation, readiness status, and API catalog links.
  * Added an agent skill discovery index for the SMS Gate skill.
  * Added response headers and endpoint handling for easier access to API and skill metadata.

* **Configuration**
  * Updated crawler directives to allow search indexing while preventing AI training and input use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->